### PR TITLE
Listunit simplify

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tts"]
+	path = tts
+	url = https://github.com/swlegion/tts.git

--- a/scripts/gobble_gobble.js
+++ b/scripts/gobble_gobble.js
@@ -1,0 +1,320 @@
+const fs = require('node:fs');
+
+fs.readFile('./cards.js', 'utf8', (err, data) => {
+  if (err) {
+    console.error(err);
+    return;
+  }
+  
+
+  let obj = JSON.parse(data);
+  
+  let ids = Object.getOwnPropertyNames(obj);
+  
+  let units = {};
+  let upgrades = [];
+  let ccs = {};
+  let battle =[];
+  let counterparts = [];
+  let flaws = [];
+  let unitNames = [];
+  
+  let cardUrls = [];
+  let iconUrls = [];
+
+  ids.forEach(id =>{
+	  
+	  let c = obj[id];
+	  cardUrls.push(`/${c.cardType}Cards/${c.imageName}`);
+	  iconUrls.push(`/${c.cardType}Icons/${c.imageName}`);
+
+	  if( c.cardType == "unit"){
+		  
+		  if(c.id != id)
+			  console.log("id mismatch!" + id);
+		  units[id] = c;
+		  
+		  return;
+		  		  
+		  let u = {};
+		  
+		  let unitName = c.cardName.toLowerCase().replaceAll(" ", "_");
+		  
+		  u.name = c.cardName;
+		  u.subtitle = c.title;
+		  u.rank = c.rank;
+		  if(u.rank == "special")
+			  u.rank = "special_forces";
+		  u.type = c.cardSubtype;
+
+		  u.courage = c.courage;
+		  u.defense=c.defense;
+		  // TODO surges
+		  if(c.surges){
+		  if(c.surges.includes("crit")){
+			  u.aSurge = 2;
+		  } else if(c.surges.includes("hit")){
+			  u.aSurge = 1;
+		  }else{
+			  u.aSurge = 0;
+		  }
+		  
+		  if(c.surges.includes("block")){
+			  u.dSurge = 1;
+		  }else{
+			  u.dSurge = 0;
+		  }
+		  }
+		  
+		  u.speed=c.speed;
+		  u.wounds=c.wounds;
+		  // TODO
+		  if(c.isUnique){
+			  u.uniqueCount = 1;
+		  }
+		  u.points = c.cost;
+		  
+		  
+		  
+		  u.faction=c.faction;
+		  switch(c.faction){
+			  case "fringe":
+				u.faction="mercenary";
+				break;
+			case "rebels":
+				u.faction="rebel";
+				break;
+			case "separatists":
+				u.faction="separatist";
+				break;
+		  }
+		  
+		  u.image = "";
+		  u.keywords = c.keywords;
+		  u.upgrades = c.upgradeBar;
+		  
+		  
+		  //console.log(u.name);
+		  if(units.hasOwnProperty(unitName)){
+				
+			  if(u.subtitle)				  
+				unitName += "_" + u.subtitle.toLowerCase().replaceAll(" ", "_");
+			  else{
+				  unitName += "_"+u.faction.toLowerCase();
+			  }
+		  }
+		  u.id = unitName;
+		  units[unitName] = u;
+		  unitNames.push(unitName);
+	}
+    else if( c.cardType == "upgrade"){
+		  
+		  let u = {};
+		  
+		  let cardName = c.cardName.toLowerCase().replaceAll(" ", "_");
+		  
+		  u.name = c.cardName;
+		  u.id = cardName;
+		  u.subtitle = c.title;
+		  u.rank = c.rank;
+		  u.type = c.cardSubtype;
+		  if(u.type == "heavy weapon"){
+			  u.type = "heavy";
+		  }
+		 
+		  // TODO
+		  if(c.isUnique){
+			  u.uniqueCount = 1;
+		  }
+		  u.points = c.cost;
+		  
+		  u.faction=c.faction;
+		  switch(c.faction){
+			  case "fringe":
+				u.faction="mercenary";
+				break;
+			case "rebels":
+				u.faction="rebel";
+				break;
+			case "separatists":
+				u.faction="separatist";
+				break;
+		  }
+		  
+		  u.image = "";
+		  if(c.keywords.length > 0){
+			u.keywords = c.keywords;
+		  }
+
+		  //console.log(u.name);
+		  
+		  upgrades.push(u);
+	}
+	
+	else if( c.cardType == "command"){
+		  
+		  let u = {};
+		  
+		  let cardName = c.cardName.toLowerCase().replaceAll(" ", "_");
+		  
+		  u.name = c.cardName;
+		  u.user = c.commander;
+		  u.pips = parseInt(c.cardSubtype);
+		 
+		  // TODO
+		  if(c.isUnique){
+			  u.uniqueCount = 1;
+		  }
+		  
+		  u.faction=c.faction;
+		  switch(c.faction){
+			  case "fringe":
+				u.faction="mercenary";
+				break;
+			case "rebels":
+				u.faction="rebel";
+				break;
+			case "separatists":
+				u.faction="separatist";
+				break;
+		  }
+		  
+		  u.image = "";
+		  if(c.keywords.length > 0){
+			u.keywords = c.keywords;
+		  }
+
+		  //console.log(u.name);
+		  if(ccs.hasOwnProperty(cardName)){
+				
+			  if(u.subtitle)				  
+				cardName += "_" + u.subtitle.toLowerCase().replaceAll(" ", "_");
+			  else{
+				  cardName += "_"+u.faction.toLowerCase();
+			  }
+		  }
+		  ccs[cardName] = u;
+	}
+	
+		else if( c.cardType == "battle"){
+			
+			battle.push(c);
+		}
+		
+		else if( c.cardType == "counterpart"){
+			//console.log(c.cardName);
+			counterparts.push(c);
+		}
+		
+		else if( c.cardType == "flaw"){
+			//console.log(c.cardName);
+			flaws.push(c);
+		}
+		
+		else{
+			console.log(c.cardName);
+			console.log(c.cardType);
+		}
+
+  });
+  
+  fs.writeFile('./units.js', "export default " + JSON.stringify(units, undefined, 4), err => {
+	  if (err) {
+		console.error(err);
+	  } else {
+		// file written successfully
+	  }
+	});
+	
+	
+	let csv = "unique, unitname, subtitle, rank, minicount, faction, unittype, def, hp, courageType, courage, speed, hitsurge, defsurge, unitkeywords, unitupgrades\n\n";
+	Object.getOwnPropertyNames(units).forEach(id=>{
+		
+		let u = units[id];
+		if(u.isOld)
+			return;
+		
+		let minicount = 4;
+		
+		if(u.rank == "commander" || u.rank =="operative" || u.rank == "heavy"){
+			minicount = 1;
+		}
+		let hitsurge="";
+        let defsurge="";		
+		if(u.surges){
+			
+			if(u.surges.includes("crit")){
+				hitsurge = "o:c";
+			}else if(u.surges.includes("hit")){
+				hitsurge = "o:h"
+			}
+			if(u.surges.includes("block")){
+				defsurge = "d:s";
+			}
+		}
+		
+		let unique = u.isUnique ? "-":"";
+		
+		let courageType = u.cardSubtype.includes("vehicle") ? "V":"m";
+		
+		let values = [unique, u.cardName, u.title, u.rank, minicount, u.faction, u.cardSubtype, u.defense=="red"?'E':'D', u.wounds, courageType, courageType=="m"? u.courage : u.resilience, u.speed, hitsurge, defsurge,u.keywords?.join("/ "), u.upgradeBar?.join("/ "), ];
+		csv += values.join(",") + "\n";
+	})
+	
+	
+	 fs.writeFile('./units.csv', csv , err => {
+		  if (err) {//fs.writeFile('./upgrades.js', "export default " +JSON.stringify(upgrades, undefined, 4), err => {
+			console.error(err);//  if (err) {
+		  } else {//	console.error(err);
+			// file written successfully//  } else {
+		  }//	// file written successfully
+		});//  }
+	//});
+	
+	fs.writeFile('./ccs.js', "export default " +JSON.stringify(ccs, undefined, 4), err => {
+	  if (err) {
+		console.error(err);
+	  } else {
+		// file written successfully
+	  }
+	});
+	
+	fs.writeFile('./ImageMap.js', "export default " +unitNames.join(": require(\"\"),\n\t"), err => {
+	  if (err) {
+		console.error(err);
+	  } else {
+		// file written successfully
+	  }
+	});
+	
+	console.log(ids.length + " Cards total");
+  	console.log(Object.getOwnPropertyNames(units).length + " Units");
+  	console.log(Object.getOwnPropertyNames(upgrades).length + " Upgrades");
+  	console.log(Object.getOwnPropertyNames(ccs).length + " CCs");
+  	console.log(battle.length + " Battle");
+	console.log(counterparts.length + " Counterparts");
+	console.log(flaws.length + " Flaws");
+	
+	
+	fs.writeFile('cardlist.txt', JSON.stringify(cardUrls), err => {
+	  if (err) {
+		console.error(err);
+	  } else {
+		// file written successfully
+	  }
+	});
+	
+	
+	fs.writeFile('iconlist.txt', JSON.stringify(iconUrls), err => {
+	  if (err) {
+		console.error(err);
+	  } else {
+		// file written successfully
+	  }
+	});
+
+
+	
+});
+
+

--- a/scripts/tts_check.js
+++ b/scripts/tts_check.js
@@ -1,0 +1,250 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+// import buildDeckSchema  from "../tts/src/lib/generate-deck-schema";
+
+
+async function readJson(inJson) {
+    const ttsJson = await fs.readJson(inJson);
+    return ttsJson;
+}
+
+
+
+function toKey(name){
+    return name.toUpperCase();
+}
+
+async function getTtsUnits(){
+
+    const ttsPathBase = "../tts/contrib/cards"
+
+    // Get the top-level json listing factions and etc
+    let inJson = path.join(ttsPathBase, 'official.json');
+    const ttsJson = await readJson(inJson); //fs.readJson(inJson);
+  
+    // Get the list of individual top-level files
+    const unitsArray = Object.entries(ttsJson['units']);
+  
+    const ttsNames = new Set();
+    const ttsUnits = new Set();
+    const ttsUpgrades = new Set();
+    const ttsCcs = new Set();
+
+
+    // Add all unit AND Command Card names (ccs are children of their unit)
+    const count = unitsArray.length;
+    for (let a = 0; a < count; a++) {
+        const faction = unitsArray[a][0];
+
+        unitsArray.forEach(f=>{
+            const unitContentPath = path.join(ttsPathBase, f[1]);
+            const rawUnitJson = fs.readFileSync(unitContentPath, 'utf-8');
+            const unitJson = JSON.parse(rawUnitJson);
+            for (const rank in unitJson) {
+                const units = unitJson[rank];
+                units.forEach(u=>{
+                    if (u.content != null) {
+                        const rawUnitEmbedContent = fs.readFileSync(
+                        "../tts/" + u.content,
+                        'utf-8',
+                        );
+                        u = JSON.parse(rawUnitEmbedContent);
+                    }
+                    u = { ...u, rank, faction };
+                    let { name } = u;
+                    if (u.title) {
+                        name = `${name} ${u.title}`;
+                    }
+                    name = toKey(name);
+
+                    ttsNames.add(name);
+                    ttsUnits.add(ttsUnits);
+
+                    if(u.commands){
+                        u.commands.forEach(c=>{
+                            if(c.name){
+                                name = toKey(c.name);
+                                ttsNames.add(name);
+                                ttsCcs.add(name);
+                            }
+                        })
+                    }
+                })
+            }
+        });
+    }
+
+    // Add all upgrades
+    const upgradeTypes = Object.entries(ttsJson['upgrades']);
+    upgradeTypes.forEach(uType =>{
+        uType[1].forEach(u=>{
+            let name = toKey(u.name);
+            ttsNames.add(name);
+            ttsUpgrades.add(name);
+        })
+    })
+
+    return {ttsNames, ttsUnits, ttsCcs, ttsUpgrades};
+}
+
+
+async function ttsCheckAsync(){
+
+    let data = await fs.readFile('../src/constants/cards.json', 'utf8')
+        
+    let obj = JSON.parse(data);
+
+    let ids = Object.getOwnPropertyNames(obj);
+
+    let units = [];
+    let upgrades = [];
+    let ccs = [];
+    let battle =[];
+    let counterparts = [];
+    let flaws = [];
+
+    let cardUrls = [];
+    let iconUrls = [];
+
+    let ttsCards = await getTtsUnits();
+
+    let count = 0;
+    ttsCards.ttsNames.values().forEach(v=>{
+        count++;
+    });
+    console.log("TTS cards count " + count);
+
+    ids.forEach(id =>{
+        
+        let c = obj[id];
+        // cardUrls.push(`/${c.cardType}Cards/${c.imageName}`);
+        // iconUrls.push(`/${c.cardType}Icons/${c.imageName}`);
+
+        if(c.id != id)
+            console.log("id mismatch!" + id);
+
+        if( c.cardType == "unit"){
+            units.push(c);
+            return;
+        }
+        else if( c.cardType == "upgrade"){
+            upgrades.push(c);
+        }   
+
+        else if( c.cardType == "command"){
+            ccs.push(c);
+        }
+
+        else if( c.cardType == "battle"){
+            battle.push(c);
+        }
+        
+        else if( c.cardType == "counterpart"){
+            //console.log(c.cardName);
+            counterparts.push(c);
+        }
+        
+        else if( c.cardType == "flaw"){
+            //console.log(c.cardName);
+            flaws.push(c);
+        }
+        
+        else{
+            console.log(c.cardName);
+            console.log(c.cardType);
+        }
+
+    });
+    
+   
+    
+    console.log(ids.length + " Cards total");
+    console.log(units.length + " Units");
+    console.log(upgrades.length + " Upgrades");
+    console.log(ccs.length + " CCs");
+    console.log(battle.length + " Battle");
+    console.log(counterparts.length + " Counterparts");
+    console.log(flaws.length + " Flaws");
+
+
+    function getName(c){
+        let name = c.cardName;
+        if(c.ttsName){
+            name = c.ttsName;
+        }
+        else if(c.title){
+            name += " " + c.title;
+        }
+        return toKey(name);
+    }
+
+    function findAndRemoveFromTtsList(name, type){
+        if(!ttsCards.ttsNames.delete(name)){
+            console.log(type + " TTS not found: " + name);
+        }
+    }
+
+    function findAndRemoveAllFromTtsList(list, typeName){
+        // console.log(list.length + " cards");// + JSON.stringify(list));
+
+        list.forEach(c=>{
+            findAndRemoveFromTtsList(getName(c), typeName);
+        })
+    }
+
+    function findAndRemoveAllStringsFromTtsList(list, typeName){
+        // console.log(list.length + " cards");// + JSON.stringify(list));
+
+        list.forEach(c=>{
+            findAndRemoveFromTtsList(c, typeName);
+        })
+    }
+
+    // console.log(units.length + " Units" + JSON.stringify(units));
+
+    findAndRemoveAllFromTtsList(units, "Unit");
+    findAndRemoveAllFromTtsList(upgrades, "Upgrades");
+    findAndRemoveAllFromTtsList(ccs, "CCs");
+    findAndRemoveAllFromTtsList(battle, "Battle");
+    findAndRemoveAllFromTtsList(counterparts, "Counterparts");
+    findAndRemoveAllFromTtsList(flaws, "Flaws");
+
+    // Generally, these are cards removed from the game
+    // TODO - evaluate these w TTS
+    let tts_exceptions = [
+        // TODO pull request made to TTS to fix typo
+        // "A BEAUTIFUL FRIENDSDHIP",
+        // TODO - figure out which wookiees are which, rename as needed
+        // "WOOKIEE WARRIORS",
+        "COMMANDING PRESENCE",
+        "INTEGRATED COMMS ANTENNA",
+        "LONG-RANGE COMLINK",
+        // "C-3PO",
+        "NOT A STORY THE JEDI WOULD TELL",
+        "FORCE LIFT",
+        // Leave this as a warning for now - we're about to get hit by it again once marskmen are out ;)
+        // "DC-15 CLONE TROOPER",
+        "RECKLESS DRIVER",
+        // TODO - pull request made to TTS to change this to '\"Nanny\" Programming', which is what both we and TTA use
+        // "NANNY PROGRAMMING",
+        // Ignore here - in this case, we export as 'offensive stance' so we're good
+        "DEFENSIVE STANCE"
+    ];
+
+    findAndRemoveAllStringsFromTtsList(tts_exceptions, "Obsolete/Redundant cards");
+
+
+    console.log("\n\n");
+
+    console.warn("TTS ENTRIES NOT FOUND IN LHQ: ")
+    ttsCards.ttsNames.forEach(n=>{
+        console.log(n);
+    })
+
+
+
+
+}
+    
+await ttsCheckAsync();

--- a/src/constants/cards.json
+++ b/src/constants/cards.json
@@ -778,7 +778,7 @@
     "al": {
         "id": "al",
         "cardName": "Rebel Commandos",
-        "title": "Stike Team",
+        "title": "Strike Team",
         "displayName": "Commando Strike Team",
         "cardType": "unit",
         "cardSubtype": "trooper",
@@ -1484,7 +1484,7 @@
     "bb": {
         "id": "bb",
         "cardName": "Scout Troopers",
-        "title": "Stike Team",
+        "title": "Strike Team",
         "displayName": "Scout Strike Team",
         "cardType": "unit",
         "cardSubtype": "trooper",
@@ -1744,6 +1744,7 @@
         "id": "bh",
         "cardName": "TX-225 GAVw Occupier Tank",
         "displayName": "Gav Tank",
+        "ttsName": "TX-225 GAVw Occupier Combat Assault Tank",
         "cardType": "unit",
         "cardSubtype": "ground vehicle",
         "rank": "heavy",
@@ -2757,7 +2758,7 @@
     "dz": {
         "displayName": "A-180 Config",
         "cardSubtype": "armament",
-        "cardName": "A-180 Configuration",
+        "cardName": "A-180 Rifle Config",
         "isUnique": false,
         "cardType": "upgrade",
         "cost": 0,
@@ -2777,7 +2778,7 @@
     "ea": {
         "displayName": "A-300 Config",
         "cardSubtype": "armament",
-        "cardName": "A-300 Configuration",
+        "cardName": "A-300 Long Range Config",
         "isUnique": false,
         "cardType": "upgrade",
         "cost": 0,
@@ -3569,7 +3570,7 @@
     "ff": {
         "displayName": "Ground Buzzer",
         "cardSubtype": "hardpoint",
-        "cardName": "Ax-108 Ground Buzzer",
+        "cardName": "Ax-108 \"Ground Buzzer\"",
         "isUnique": false,
         "cardType": "upgrade",
         "cost": 10,
@@ -3593,7 +3594,7 @@
     "fg": {
         "displayName": "Power Harpoon",
         "cardSubtype": "hardpoint",
-        "cardName": "MoDk Power Harpoon",
+        "cardName": "MO/DK Power Harpoon",
         "isUnique": false,
         "cardType": "upgrade",
         "cost": 0,
@@ -4518,7 +4519,7 @@
     "gn": {
         "displayName": "E-11D Config",
         "cardSubtype": "armament",
-        "cardName": "E-11D Configuration",
+        "cardName": "E-11D Focused Fire Config",
         "isUnique": false,
         "cardType": "upgrade",
         "cost": 0,
@@ -5231,7 +5232,7 @@
     "hq": {
         "displayName": "DC-15 Trooper",
         "cardSubtype": "heavy weapon",
-        "cardName": "DC-15 Phase I Trooper",
+        "cardName": "DC-15 Clone Trooper",
         "isUnique": false,
         "cardType": "upgrade",
         "cost": 24,
@@ -5631,8 +5632,7 @@
         "detachment": "gv"
     },
     "ig": {
-        "cardName": "CM-O 93 Trooper",
-        "displayName": "CM-0/93 Trooper",
+        "cardName": "CM-0/93 Trooper",
         "cardSubtype": "heavy weapon",
         "isUnique": false,
         "cardType": "upgrade",
@@ -6722,7 +6722,8 @@
     },
     "kh": {
         "cardSubtype": "armament",
-        "cardName": "A280-CFE Config",
+        "displayName": "A280-CFE Config",
+        "cardName": "A280-CFE Sniper Config",
         "isUnique": false,
         "cardType": "upgrade",
         "cost": 0,
@@ -6966,7 +6967,7 @@
         "id": "kt",
         "displayName": "\"Bunker Buster\" Shells",
         "cardSubtype": "ordnance",
-        "cardName": "Bunker Buster Shells",
+        "cardName": "\"Bunker Buster\" Shells",
         "isUnique": false,
         "cardType": "upgrade",
         "cost": 12,
@@ -7360,7 +7361,7 @@
         "id": "le",
         "displayName": "EMP \"Droid Poppers\"",
         "cardSubtype": "grenades",
-        "cardName": "EMP Droid Poppers",
+        "cardName": "EMP \"Droid Poppers\"",
         "isUnique": false,
         "cardType": "upgrade",
         "cost": 3,
@@ -7431,6 +7432,7 @@
         "cardSubtype": "heavy weapon",
         "cardName": "Echo",
         "title": "ARC Marksman",
+        "ttsName": "Echo, ARC Marskman",
         "isUnique": true,
         "cardType": "upgrade",
         "prevCost": 42,
@@ -8753,7 +8755,7 @@
         "id": "np",
         "displayName": "",
         "cardSubtype": "armament",
-        "cardName": "J-19 Bo-rifle Staff",
+        "cardName": "J-19 Bo-rifle Blaster",
         "isUnique": true,
         "cardType": "upgrade",
         "cost": 5,
@@ -9260,7 +9262,7 @@
     },
     "on": {
         "id": "on",
-        "cardName": "LAAT Patrol Transport",
+        "cardName": "LAAT/le Patrol Transport",
         "cardType": "unit",
         "cardSubtype": "repulsor vehicle",
         "rank": "heavy",
@@ -9306,7 +9308,7 @@
     },
     "oo": {
         "id": "oo",
-        "cardName": "LAAT Patrol Transport",
+        "cardName": "LAAT/le Patrol Transport",
         "cardType": "unit",
         "cardSubtype": "repulsor vehicle",
         "rank": "heavy",
@@ -9727,6 +9729,7 @@
         "displayName": "",
         "cardSubtype": "heavy weapon",
         "cardName": "Battle Shield Wookiee",
+        "ttsName": "Battle Shield Wookiee (Offensive)",
         "isUnique": false,
         "cardType": "upgrade",
         "cost": 26,
@@ -10664,6 +10667,7 @@
         "id": "qu",
         "cardSubtype": "pilot",
         "cardName": "327th Star Corps Pilot",
+        "ttsName":"327th Star Corps Elite Armor Pilots",
         "isUnique": false,
         "cardType": "upgrade",
         "prevCost": 5,
@@ -11257,6 +11261,7 @@
         "cardSubtype": "armament",
         "cardName": "Maul The Darksaber",
         "displayName": "The Darksaber",
+        "ttsName" : "The Darksaber (Maul)",
         "isUnique": true,
         "cardType": "upgrade",
         "cost": 10,
@@ -11738,7 +11743,8 @@
     "sr": {
         "id": "sr",
         "cardName": "Stormtroopers",
-        "displayName": "Stormtroopers Heavy Response Unit",
+        "title" : "Heavy Response Unit",
+        "displayName": "Stormtroopers HRU",
         "cardType": "unit",
         "cardSubtype": "trooper",
         "rank": "corps",
@@ -12605,6 +12611,7 @@
         "cardSubtype": "armament",
         "cardName": "Moff Gideon The Darksaber",
         "displayName": "The Darksaber",
+        "ttsName" : "The Darksaber (Gideon)",
         "isUnique": true,
         "cardType": "upgrade",
         "cost": 15,
@@ -12859,84 +12866,6 @@
 				"description": "Now divulged during resolve setup effects step rather than deploy units step."
 			}
         ]
-    },
-    "uy-to-be-deleted": {
-        "id": "uy",
-        "cardName": "Imperial Death Troopers",
-        "displayName": "Death Troopers",
-        "cardType": "unit",
-        "cardSubtype": "trooper",
-        "rank": "corps",
-        "faction": "empire",
-        "isUnique": false,
-        "cost": 72,
-        "imageName": "Imperial Death Troopers.webp",
-        "keywords": [
-            "Disciplined",
-            "Precise",
-            "Ready"
-        ],
-        "upgradeBar": [
-            "heavy weapon",
-            "training",
-            "comms",
-            "gear",
-            "armament",
-            "grenades"
-        ],
-        "defense": "red",
-        "surges": [
-            "hit",
-            "block"
-        ],
-        "wounds": 1,
-        "courage": 2,
-        "speed": 2,
-        "history": [
-            {
-                "date": "27 October 2021",
-                "description": "Cost reduced from 76 to 72 points."
-            }
-        ],
-        
-        "specialIssue": "Imperial Remnant"
-    },
-    "uz-to-be-deleted": {
-        "id": "uz",
-        "cardName": "Scout Troopers",
-        "cardType": "unit",
-        "cardSubtype": "trooper",
-        "rank": "corps",
-        "faction": "empire",
-        "isUnique": false,
-        "cost": 48,
-        "imageName": "Scout Troopers.webp",
-        "keywords": [
-            "Low Profile",
-            "Scout",
-            "Sharpshooter"
-        ],
-        "upgradeBar": [
-            "heavy weapon",
-            "training",
-            "comms",
-            "gear",
-            "grenades"
-        ],
-        "defense": "white",
-        "surges": [
-            "block"
-        ],
-        "wounds": 1,
-        "courage": 2,
-        "speed": 2,
-        "history": [
-            {
-                "date": "19 November 2020",
-                "description": "Cost reduced from 60 to 48 points."
-            }
-        ],
-        "specialIssue": "Imperial Remnant"
     },
     "va": {
         "id": "va",
@@ -14152,39 +14081,6 @@
         "speed": 2,
         "specialIssue": "Wookiee Defenders"
     },
-    "xg-to-be-deleted": {
-        "id": "xg",
-        "cardName": "Wookiee Warriors",
-        "title": "Noble Fighters",
-        "cardType": "unit",
-        "cardSubtype": "wookiee trooper",
-        "rank": "corps",
-        "faction": "republic",
-        "isUnique": false,
-        "cost": 69,
-        "imageName": "Wookiee Warriors Noble Fighters.webp",
-        "keywords": [
-            "Charge",
-            "Duelist",
-            "Indomitable",
-            "Scale"
-        ],
-        "upgradeBar": [
-            "heavy weapon",
-            "training",
-            "training",
-            "gear",
-            "grenades"
-        ],
-        "defense": "white",
-        "surges": [
-            "hit"
-        ],
-        "wounds": 3,
-        "courage": 2,
-        "speed": 2,
-        "specialIssue": "Wookiee Defenders"
-    },
     "xh": {
         "id": "xh",
         "cardName": "Range Troopers",
@@ -14355,7 +14251,6 @@
 	"xp": {
         "id": "xp",
         "cardName": "Clone Commandos Delta Squad",
-        "title": "Delta Squad",
         "displayName": "Delta Squad",
         "cardType": "unit",
         "cardSubtype": "clone trooper",
@@ -14394,6 +14289,7 @@
 		"id": "xq",
 		"cardSubtype": "heavy weapon",
 		"cardName": "Echo",
+        "ttsName":"Echo (The Bad Batch)",
 		"isUnique": true,
 		"cardType": "upgrade",
 		"cost": 0,
@@ -14406,6 +14302,7 @@
 		"id": "xr",
 		"cardSubtype": "heavy weapon",
 		"cardName": "Hunter",
+        "ttsName":"Hunter (The Bad Batch)",
 		"isUnique": true,
 		"cardType": "upgrade",
 		"cost": 0,
@@ -14496,6 +14393,7 @@
 	"xw": {
 		"cardName": "Omega",
 		"title": "Mascot of the 99th",
+        "ttsName":"Omega",
 		"faction": "mercenary",
 		"affiliations": ["rebels"],
 		"isUnique": true,

--- a/src/constants/listOperations.js
+++ b/src/constants/listOperations.js
@@ -498,39 +498,39 @@ function generateTTSJSONText(list) {
 function appendMissionTTSJSON(cardList, ttsArray){
 
   for (let i = 0; i < cardList.length; i++) {
-    if (idToName[cardList[i]]) {
-      ttsArray.push(idToName[cardList[i]]);
-    } else {
+    // if (idToName[cardList[i]]) {
+    //   ttsArray.push(idToName[cardList[i]]);
+    // } else {
       const battlefieldCard = cards[cardList[i]];
       ttsArray.push(battlefieldCard.cardName);
-    }
+    // }
   }
 
 }
   const idToName = {
-    "nc": "Offensive Stance",
-    "dz": "A-180 Config",
-    "ea": "A-300 Config",
-    "kh": "A-280-CFE Config",
-    "gn": "E-11D Config",
-    "np": "J-19 Bo-rifle",
-    "Ci": "Clear Conditions",
-    "Cl": "War Weary",
-    "Dj": "Battle Lines",
-    "ff": "Ax-108 \"Ground Buzzer\"",
-    "fg": "Mo/Dk Power Harpoon",
-    "bh": "TX-225 GAVw Occupier Combat Assault Tank",
-    "on": "LAAT/le Patrol Transport",
-    "oo": "LAAT/le Patrol Transport",
-    "ig": "CM-0/93 Trooper",
-    "kd": "Z-6 Phase II Trooper",
-    "kt": "\"Bunker Buster\" Shells",
-    "le": "EMP \"Droid Poppers\"",
-    "lw": "Iden's ID10 Seeker Droid",
-    "sr": "Stormtroopers Heavy Response Unit",
-    "uj": "The Darksaber (Gideon)",
-    "rq": "The Darksaber (Maul)",
-    "xw": "Echo (The Bad Batch)"
+    // "nc": "Offensive Stance",
+    // "dz": "A-180 Config",
+    // "ea": "A-300 Config",
+    // "kh": "A-280-CFE Config",
+    // "gn": "E-11D Config",
+    // "np": "J-19 Bo-rifle",
+    // "Ci": "Clear Conditions",
+    // "Cl": "War Weary",
+    // "Dj": "Battle Lines",
+    // "ff": "Ax-108 \"Ground Buzzer\"",
+    // "fg": "Mo/Dk Power Harpoon",
+    // "bh": "TX-225 GAVw Occupier Combat Assault Tank",
+    // "on": "LAAT/le Patrol Transport",
+    // "oo": "LAAT/le Patrol Transport",
+    // "ig": "CM-0/93 Trooper",
+    // "kd": "Z-6 Phase II Trooper",
+    // "kt": "\"Bunker Buster\" Shells",
+    // "le": "EMP \"Droid Poppers\"",
+    // "lw": "Iden's ID10 Seeker Droid",
+    // "sr": "Stormtroopers Heavy Response Unit",
+    // "uj": "The Darksaber (Gideon)",
+    // "rq": "The Darksaber (Maul)",
+    // "xw": "Echo (The Bad Batch)"
   };
 
   ttsJSON.listname = list.title;
@@ -568,29 +568,30 @@ function appendMissionTTSJSON(cardList, ttsArray){
     const unit = list.units[i];
     const unitCard = cards[unit.unitId];
 
-    if (idToName[unit.unitId]) unitJSON.name = idToName[unit.unitId];
+    if(unit.ttsName) unitJSON.name = unit.ttsName;
+    // else if (idToName[unit.unitId]) unitJSON.name = idToName[unit.unitId];
     else if (unitCard.title) unitJSON.name = `${unitCard.cardName} ${unitCard.title}`;
     else unitJSON.name = unitCard.cardName;
 
     for (let j = 0; j < unit.upgradesEquipped.length; j++) {
       if (unit.upgradesEquipped[j]) {
-        if (idToName[unit.upgradesEquipped[j]]) {
-          unitJSON.upgrades.push(idToName[unit.upgradesEquipped[j]]);
-        } else {
+        // if (idToName[unit.upgradesEquipped[j]]) {
+        //   unitJSON.upgrades.push(idToName[unit.upgradesEquipped[j]]);
+        // } else {
           const upgradeCard = cards[unit.upgradesEquipped[j]];
           unitJSON.upgrades.push(upgradeCard.cardName);
-        }
+        // }
       }
     }
     if (unit.loadoutUpgrades) {
       for (let j = 0; j < unit.loadoutUpgrades.length; j++) {
         if (unit.loadoutUpgrades[j]) {
-          if (idToName[unit.loadoutUpgrades[j]]) {
-            unitJSON.loadout.push(idToName[unit.loadoutUpgrades[j]]);
-          } else {
+        //   if (idToName[unit.loadoutUpgrades[j]]) {
+        //     unitJSON.loadout.push(idToName[unit.loadoutUpgrades[j]]);
+        //   } else {
             const upgradeCard = cards[unit.loadoutUpgrades[j]];
             unitJSON.loadout.push(upgradeCard.cardName);
-          }
+        //   }
         }
       }
     }
@@ -600,23 +601,23 @@ function appendMissionTTSJSON(cardList, ttsArray){
       unitJSON.upgrades.push(`${counterpartCard.cardName}${counterpartCard.title ? ` ${counterpartCard.title}}` : ''}`);
       for (let j = 0; j < counterpart.upgradesEquipped.length; j++) {
         if (counterpart.upgradesEquipped[j]) {
-          if (idToName[counterpart.upgradesEquipped[j]]) {
-            unitJSON.upgrades.push(idToName[counterpart.upgradesEquipped[j]]);
-          } else {
+        //   if (idToName[counterpart.upgradesEquipped[j]]) {
+        //     unitJSON.upgrades.push(idToName[counterpart.upgradesEquipped[j]]);
+        //   } else {
             const upgradeCard = cards[counterpart.upgradesEquipped[j]];
             unitJSON.upgrades.push(upgradeCard.cardName);
-          }
+        //   }
         }
       }
       if (counterpart.loadoutUpgrades) {
         for (let j = 0; j < counterpart.loadoutUpgrades.length; j++) {
           if (counterpart.loadoutUpgrades[j]) {
-            if (idToName[counterpart.loadoutUpgrades[j]]) {
-              unitJSON.loadout.push(idToName[counterpart.loadoutUpgrades[j]]);
-            } else {
+            // if (idToName[counterpart.loadoutUpgrades[j]]) {
+            //   unitJSON.loadout.push(idToName[counterpart.loadoutUpgrades[j]]);
+            // } else {
               const upgradeCard = cards[counterpart.loadoutUpgrades[j]];
               unitJSON.loadout.push(upgradeCard.cardName);
-            }
+            // }
           }
         }
       }

--- a/src/constants/listOperations.js
+++ b/src/constants/listOperations.js
@@ -1541,7 +1541,7 @@ function equipUpgrade(list, action, unitIndex, upgradeIndex, upgradeId, isApplyT
     }
   } else if (action === 'COUNTERPART_UPGRADE') {
     list = equipCounterpartUpgrade(list, unitIndex, upgradeIndex, upgradeId);
-  } else if (action === 'LOADOUT_UPGRADE') {
+  } else if (action === 'UNIT_LOADOUT_UPGRADE') {
     list = equipLoadoutUpgrade(list, unitIndex, upgradeIndex, upgradeId);
   } else if (action === 'COUNTERPART_LOADOUT_UPGRADE') {
     list = equipCounterpartLoadoutUpgrade(list, unitIndex, upgradeIndex, upgradeId);
@@ -1585,7 +1585,7 @@ function unequipUpgrade(list, action, unitIndex, upgradeIndex) {
     list = unequip(list, unitIndex, upgradeIndex);
   } else if (action === 'COUNTERPART_UPGRADE') {
     list = unequipCounterpartUpgrade(list, unitIndex, upgradeIndex);
-  } else if (action === 'LOADOUT_UPGRADE') {
+  } else if (action === 'UNIT_LOADOUT_UPGRADE') {
     list = unequipLoadoutUpgrade(list, unitIndex, upgradeIndex);
   } else if (action === 'COUNTERPART_LOADOUT_UPGRADE') {
     list = unequipCounterpartLoadoutUpgrade(list, unitIndex, upgradeIndex);

--- a/src/context/UnitContext.js
+++ b/src/context/UnitContext.js
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const UnitContext = createContext();
+
+export default UnitContext;

--- a/src/pages/List/CardSelector/index.js
+++ b/src/pages/List/CardSelector/index.js
@@ -93,7 +93,7 @@ function CardSelector() {
       const upgradeIds = getEquippableUpgrades(
       currentList,
       cardPaneFilter.upgradeType,
-      cardPaneFilter.counterpartId,
+      cardPaneFilter.unitId,
       cardPaneFilter.upgradesEquipped,
       cardPaneFilter.additionalUpgradeSlots
     );
@@ -106,7 +106,7 @@ function CardSelector() {
       upgradeId
     );
     header = <Title title="Add counterpart upgrade" />;
-  } else if (action === 'LOADOUT_UPGRADE') {
+  } else if (action === 'UNIT_LOADOUT_UPGRADE') {
     const upgradeIds = getEquippableLoadoutUpgrades(
       currentList,
       cardPaneFilter.upgradeType,
@@ -118,7 +118,7 @@ function CardSelector() {
     validIds = upgradeIds.validIds;
     invalidIds = upgradeIds.invalidIds;
     clickHandler = (upgradeId) => handleEquipUpgrade(
-      'LOADOUT_UPGRADE',
+      'UNIT_LOADOUT_UPGRADE',
       cardPaneFilter.unitIndex,
       cardPaneFilter.upgradeIndex,
       upgradeId
@@ -127,7 +127,7 @@ function CardSelector() {
   } else if (action === 'COUNTERPART_LOADOUT_UPGRADE') {
     const {
       upgradeType,
-      counterpartId,
+      unitId,
       upgradeIndex,
       upgradesEquipped,
       additionalUpgradeSlots
@@ -135,7 +135,7 @@ function CardSelector() {
     const upgradeIds = getEquippableLoadoutUpgrades(
       currentList,
       upgradeType,
-      counterpartId,
+      unitId,
       upgradeIndex,
       upgradesEquipped,
       additionalUpgradeSlots

--- a/src/pages/List/ListHeader/ListRulesModal.js
+++ b/src/pages/List/ListHeader/ListRulesModal.js
@@ -162,8 +162,6 @@ function RankLimits({list}){
                   }
                 }
 
-                // console.log("l " + JSON.stringify(unitLimits) + " " + limit);
-
                 let display = limit + " " + name;
 
                 let suffix = idx < bf[r].length -1 ? ",": ""

--- a/src/pages/List/ListUnits/CounterpartUnit.js
+++ b/src/pages/List/ListUnits/CounterpartUnit.js
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import UnitAvatar from 'common/UnitAvatar';
 import CardName from 'common/CardName';
 import UnitPoints from 'common/UnitPoints';
 import UnitActions from './UnitActions';
 import UnitUpgrades from './UnitUpgrades';
+import UnitContext from 'context/UnitContext';
+import ListContext from 'context/ListContext';
 
 const useStyles = makeStyles(theme => ({
   unitRow: {
@@ -31,47 +33,30 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-function CounterpartUnit({
-  counterpart,
-  counterpartId,
-  counterpartCard,
-  unitIndex,
-  handleCardZoom,
-  zoomUpgradeHandlers,
-  swapUpgradeHandlers,
-  addUpgradeHandlers,
-  deleteUpgradeHandlers,
-  changeLoadoutHandlers,
-  deleteLoadoutHandlers,
-}) {
+function CounterpartUnit() {
   const classes = useStyles();
+
+  const {unit, unitCard, unitIndex} = useContext(UnitContext);
+  const {handleCardZoom} = useContext(ListContext);
+
   return (
     <div className={classes.unitRow}>
       <div className={classes.leftCell}>
         <UnitAvatar
             key="avatar"
-            id={counterpartId}
-            handleClick={handleCardZoom}
+            id={unitCard.id}
+            handleClick={() => handleCardZoom(unitCard.id)}
         />      
       </div>
       <div className={classes.middleCell}>
-        <CardName key="name" id={counterpartId} />      
+        <CardName key="name" id={unitCard.id} />      
         <UnitUpgrades
           key="upgrades"
-          upgradesEquipped={counterpart.upgradesEquipped}
-          totalUpgradeBar={counterpartCard.upgradeBar}
-          loadoutUpgrades={counterpart.loadoutUpgrades}
-          zoomUpgradeHandlers={zoomUpgradeHandlers}
-          swapUpgradeHandlers={swapUpgradeHandlers}
-          addUpgradeHandlers={addUpgradeHandlers}
-          deleteUpgradeHandlers={deleteUpgradeHandlers}
-          changeLoadoutHandlers={changeLoadoutHandlers}
-          deleteLoadoutHandlers={deleteLoadoutHandlers}
         />
       </div>
       <div className={classes.rightCell}>
-        <UnitPoints key="points" unit={counterpart} parentheses={true}/>
-        <UnitActions unit={counterpart} unitIndex={unitIndex} isCounterpart={true}/>
+        <UnitPoints key="points" unit={unit} parentheses={true}/>
+        <UnitActions unit={unit} unitIndex={unitIndex} isCounterpart={true}/>
       </div>
     </div>
   );

--- a/src/pages/List/ListUnits/ListUnit.js
+++ b/src/pages/List/ListUnits/ListUnit.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import UnitAvatar from 'common/UnitAvatar';
 import CardName from 'common/CardName';
@@ -6,6 +6,8 @@ import UnitPoints from 'common/UnitPoints';
 import UnitActions from './UnitActions';
 import UnitUpgrades from './UnitUpgrades';
 import UnitFlaw from './UnitFlaw';
+import UnitContext from 'context/UnitContext';
+import ListContext from 'context/ListContext';
 
 const useStyles = makeStyles(theme => ({
   unitRow: {
@@ -33,38 +35,19 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function ListUnit({
-  unit,
-  uniques,
-  unitCard,
-  unitIndex,
-  counterpartId,
   counterpartUnit,
-  handleCardZoom,
   addCounterpartHandler,
-  zoomUpgradeHandlers,
-  swapUpgradeHandlers,
-  addUpgradeHandlers,
-  deleteUpgradeHandlers,
-  changeLoadoutHandlers,
-  deleteLoadoutHandlers
 }) {
   const classes = useStyles();
+
+  const {unit, unitIndex, unitCard} = useContext(UnitContext);
+  const {handleCardZoom} = useContext(ListContext);
 
   const upgrades = (
     <UnitUpgrades
       key="upgrades"
-      counterpartId={counterpartId}
-      upgradesEquipped={unit.upgradesEquipped}
-      upgradeInteractions={unit.upgradeInteractions}
-      totalUpgradeBar={[...unitCard.upgradeBar, ...unit.additionalUpgradeSlots]}
-      loadoutUpgrades={unit.loadoutUpgrades}
+      counterpartId={unitCard.counterpartId}
       addCounterpartHandler={addCounterpartHandler}
-      swapUpgradeHandlers={swapUpgradeHandlers}
-      zoomUpgradeHandlers={zoomUpgradeHandlers}
-      addUpgradeHandlers={addUpgradeHandlers}
-      deleteUpgradeHandlers={deleteUpgradeHandlers}
-      changeLoadoutHandlers={changeLoadoutHandlers}
-      deleteLoadoutHandlers={deleteLoadoutHandlers}
     />
   );
   const flaws = unitCard.flaw ? <UnitFlaw key="flaws" flawId={unitCard.flaw} /> : undefined;
@@ -77,7 +60,7 @@ function ListUnit({
             key="avatar"
             id={unitCard.id}
             count={unit.count}
-            handleClick={handleCardZoom}
+            handleClick={() => handleCardZoom(unit.unitId)}
           />
         </div>
         <div className={classes.middleCell}>

--- a/src/pages/List/ListUnits/UnitUpgrades.js
+++ b/src/pages/List/ListUnits/UnitUpgrades.js
@@ -17,7 +17,6 @@ function UnitUpgrades({
   const hasLoadout = unit.loadoutUpgrades ? unit.loadoutUpgrades.length > 0 : false;
 
   const {setCardPaneFilter, handleCardZoom} = useContext(ListContext);
-  console.log("TODO REMOVE" + unitCard.cardName);
 
   if (addCounterpartHandler) {
     addCounterpartButtons.push(
@@ -43,9 +42,6 @@ function UnitUpgrades({
         />
       );
     } else {
-
-      console.log("TODO REMOVE " + actionPrefix + "_UPGRADE");
-
       addUpgradesButtons.push(
         <AddUpgradeButton
           key={`${totalUpgradeBar[upgradeIndex]}_${upgradeIndex}`}

--- a/src/pages/List/ListUnits/UnitUpgrades.js
+++ b/src/pages/List/ListUnits/UnitUpgrades.js
@@ -1,26 +1,24 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import AddCounterpartButton from './AddCounterpartButton';
 import AddUpgradeButton from './AddUpgradeButton';
 import UpgradeChip from './UpgradeChip';
+import ListContext from 'context/ListContext';
+import UnitContext from 'context/UnitContext';
 
 function UnitUpgrades({
   counterpartId,
-  upgradesEquipped,
-  upgradeInteractions,
-  totalUpgradeBar,
-  loadoutUpgrades,
   addCounterpartHandler,
-  zoomUpgradeHandlers,
-  swapUpgradeHandlers,
-  addUpgradeHandlers,
-  deleteUpgradeHandlers,
-  changeLoadoutHandlers,
-  deleteLoadoutHandlers
 }) {
+
+  const {unit, unitIndex, unitCard, totalUpgradeBar, actionPrefix} = useContext(UnitContext);
   const addCounterpartButtons = [];
   const addUpgradesButtons = [];
   const upgradeChips = [];
-  const hasLoadout = loadoutUpgrades ? loadoutUpgrades.length > 0 : false;
+  const hasLoadout = unit.loadoutUpgrades ? unit.loadoutUpgrades.length > 0 : false;
+
+  const {setCardPaneFilter, handleCardZoom} = useContext(ListContext);
+  console.log("TODO REMOVE" + unitCard.cardName);
+
   if (addCounterpartHandler) {
     addCounterpartButtons.push(
       <AddCounterpartButton
@@ -30,27 +28,41 @@ function UnitUpgrades({
       />
     );
   }
-  upgradesEquipped.forEach((upgradeId, upgradeIndex) => {
+  unit.upgradesEquipped.forEach((upgradeId, upgradeIndex) => {
+    const upgradeType = totalUpgradeBar[upgradeIndex];
+
     if (upgradeId) {
       upgradeChips.push(
         <UpgradeChip
+          unitIndex={unitIndex}
+          upgradeIndex={upgradeIndex}
           key={upgradeId}
           upgradeId={upgradeId}
-          upgradeInteractions={upgradeInteractions}
-          loadoutId={hasLoadout ? loadoutUpgrades[upgradeIndex] : undefined}
-          handleClick={zoomUpgradeHandlers[upgradeIndex]}
-          handleSwap={swapUpgradeHandlers[upgradeIndex]}
-          handleDelete={deleteUpgradeHandlers[upgradeIndex]}
-          handleChangeLoadout={changeLoadoutHandlers[upgradeIndex]}
-          handleDeleteLoadout={deleteLoadoutHandlers[upgradeIndex]}
+          loadoutId={hasLoadout ? unit.loadoutUpgrades[upgradeIndex] : undefined}
+          handleClick={() => handleCardZoom(upgradeId)}
         />
       );
     } else {
+
+      console.log("TODO REMOVE " + actionPrefix + "_UPGRADE");
+
       addUpgradesButtons.push(
         <AddUpgradeButton
           key={`${totalUpgradeBar[upgradeIndex]}_${upgradeIndex}`}
           type={totalUpgradeBar[upgradeIndex]}
-          handleClick={addUpgradeHandlers[upgradeIndex]}
+          // handleClick={addUpgradeHandlers[upgradeIndex]}
+          handleClick={
+            () =>{ 
+              setCardPaneFilter({
+                action: actionPrefix + '_UPGRADE',
+                upgradeType, unitIndex, upgradeIndex,
+                hasUniques: unit.hasUniques,
+                unitId: unitCard.id,
+                upgradesEquipped: unit.upgradesEquipped,
+                additionalUpgradeSlots: unit.additionalUpgradeSlots
+              })
+          }
+          }
         />
       );
     }

--- a/src/pages/List/ListUnits/UpgradeChip.js
+++ b/src/pages/List/ListUnits/UpgradeChip.js
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Divider, Chip, Button, IconButton, Icon, Typography } from '@material-ui/core';
 import { Clear as ClearIcon } from '@material-ui/icons';
 import CardIcon from 'common/CardIcon';
 import cards from 'constants/cards';
 import loadoutIcon from 'assets/loadout.png';
+import ListContext from 'context/ListContext';
+import UnitContext from 'context/UnitContext';
 
 function UpgradeLabel({ card, handleSwapUpgrade, handleChangeLoadout }) {
+
+
+  const {unit} = useContext(UnitContext);
+
+  const hasLoadout = unit.loadoutUpgrades ? unit.loadoutUpgrades.length > 0 : false;
+  // console.log('hasloadout: ' + hasLoadout + " "+ JSON.stringify(unit.loadoutUpgrades));
+
   if (handleChangeLoadout) {
     return (
       <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -14,7 +23,7 @@ function UpgradeLabel({ card, handleSwapUpgrade, handleChangeLoadout }) {
             card.displayName :
             card.cardName} (${card.cost})`}
         </Typography>
-        {Boolean(handleChangeLoadout) && (
+        {hasLoadout && (
           <IconButton
             size="small"
             onClick={handleChangeLoadout}
@@ -46,7 +55,7 @@ function UpgradeLabel({ card, handleSwapUpgrade, handleChangeLoadout }) {
             card.cardName} (${card.cost})`}
         </Typography>
       </Button>
-      {Boolean(handleChangeLoadout) && (
+      {hasLoadout && (
         <IconButton
           size="small"
           onClick={handleChangeLoadout}
@@ -109,37 +118,66 @@ function UpgradeChip({
   upgradeId,
   loadoutId,
   handleClick,
-  handleSwap,
-  handleDelete,
-  handleChangeLoadout,
-  handleDeleteLoadout
+  upgradeIndex
 }) {
   const upgradeCard = cards[upgradeId];
   const loadoutCard = cards[loadoutId];
+
+  const {handleUnequipUpgrade, setCardPaneFilter} = useContext(ListContext);
+
+  const {unitCard, unitIndex, unit, totalUpgradeBar, actionPrefix } = useContext(UnitContext);
+
+  const upgradeType = totalUpgradeBar[upgradeIndex];
+
   let pointDelta = 0;
   if (upgradeInteractions && upgradeId in upgradeInteractions) {
     pointDelta = upgradeInteractions[upgradeId];
   }
+  const hasLoadout = unit.loadoutUpgrades.length > 0;
+
   return (
     <Chip
       size={chipSize}
-      label={loadoutCard ? (
+      label={(hasLoadout && loadoutCard) ? (
         <LoadoutLabel
           upgradeCard={{ ...upgradeCard, cost: upgradeCard.cost + pointDelta }}
           loadoutCard={loadoutCard}
-          handleChangeLoadout={handleChangeLoadout}
-          handleDeleteLoadout={handleDeleteLoadout}
+          handleChangeLoadout={() => setCardPaneFilter({
+            action: actionPrefix+'_LOADOUT_UPGRADE',
+            upgradeType, unitIndex, upgradeIndex,
+            unitId: unitCard.id,
+            upgradesEquipped: unit.upgradesEquipped,
+            additionalUpgradeSlots: unit.additionalUpgradeSlots
+          })}
+          handleDeleteLoadout={() => handleUnequipUpgrade(
+            actionPrefix+'_LOADOUT_UPGRADE', unitIndex, upgradeIndex
+          )}
         />
       ) : (
         <UpgradeLabel
           card={{ ...upgradeCard, cost: upgradeCard.cost + pointDelta }}
-          handleSwapUpgrade={handleSwap}
-          handleChangeLoadout={handleChangeLoadout}
+          handleSwapUpgrade={() => setCardPaneFilter({
+            action: actionPrefix+'_UPGRADE',
+            upgradeType, unitIndex, upgradeIndex,
+            hasUniques: unit.hasUniques,
+            unitId: unitCard.id,
+            upgradesEquipped: unit.upgradesEquipped,
+            additionalUpgradeSlots: unit.additionalUpgradeSlots
+          })}
+          handleChangeLoadout={() => setCardPaneFilter({
+            action: actionPrefix+'_LOADOUT_UPGRADE',
+            upgradeType, unitIndex, upgradeIndex,
+            unitId: unitCard.id,
+            upgradesEquipped: unit.upgradesEquipped,
+            additionalUpgradeSlots: unit.additionalUpgradeSlots
+          })}
         />
       )}
       avatar={<UpgradeAvatar card={upgradeCard} handleClick={handleClick} />}
       style={{ marginRight: 4, marginTop: 4, marginBottom: 6, height: 'auto' }}
-      onDelete={handleDelete}
+      onDelete={ () => handleUnequipUpgrade(
+        actionPrefix+'_UPGRADE', unitIndex, upgradeIndex
+      )}
     />
   );
 };

--- a/src/pages/List/ListUnits/UpgradeChip.js
+++ b/src/pages/List/ListUnits/UpgradeChip.js
@@ -13,8 +13,7 @@ function UpgradeLabel({ card, handleSwapUpgrade, handleChangeLoadout }) {
   const {unit} = useContext(UnitContext);
 
   const hasLoadout = unit.loadoutUpgrades ? unit.loadoutUpgrades.length > 0 : false;
-  // console.log('hasloadout: ' + hasLoadout + " "+ JSON.stringify(unit.loadoutUpgrades));
-
+  
   if (handleChangeLoadout) {
     return (
       <div style={{ display: 'flex', alignItems: 'center' }}>

--- a/src/pages/List/ListUnits/index.js
+++ b/src/pages/List/ListUnits/index.js
@@ -4,195 +4,67 @@ import DragDropContainer from './DragDropContainer';
 import ListUnit from './ListUnit';
 import CounterpartUnit from './CounterpartUnit';
 import cards from 'constants/cards';
+import UnitContext from 'context/UnitContext';
 
 function ListUnits() {
   const {
     currentList,
     reorderUnits,
     setCardPaneFilter,
-    handleUnequipUpgrade,
-    handleCardZoom,
-    handleRemoveCounterpart,
   } = React.useContext(ListContext);
 
   const items = currentList.units.map((unit, unitIndex) => {
     const unitCard = cards[unit.unitId];
     const { counterpartId } = unitCard;
     const counterpartCard = cards[counterpartId];
-    const { loadoutUpgrades } = unit;
-    const hasLoadout = loadoutUpgrades ? loadoutUpgrades.length > 0 : false;
-    let counterpartUnit;
+    let counterpartUnit = null;
     let addCounterpartHandler;
-    const addUpgradeHandlers = [];
-    const zoomUpgradeHandlers = [];
-    const swapUpgradeHandlers = [];
-    const deleteUpgradeHandlers = [];
-    const changeLoadoutHandlers = [];
-    const deleteLoadoutHandlers = [];
-    const totalUpgradeBar = [...unitCard.upgradeBar, ...unit.additionalUpgradeSlots];
     
     if(counterpartId){
-      // Show counterpart add icon(s) if unit has one and not already in list
+      // Show counterpart add icon(s) if unit has a counterpart option and it's not already in list
       if (!currentList.uniques.includes(counterpartId)){
-        // general case (not IG-11) & Special case for IG-11 (tj) + 'Nanny Programming' (tp)
+        // general case (not IG-11) || IG-11 (tj) + 'Nanny Programming' (tp)
         if(unit.unitId != 'tj' || unit.unitId == 'tj' && currentList.uniques.includes('tp')){
           addCounterpartHandler = () => setCardPaneFilter({
             action: 'COUNTERPART', unitIndex, counterpartId
           });
         }
       }
-      // else, if list has the counterpart added, render the counterpart row + upgrades (if applicable)
+      // else, if unit has counterpart equipped, render it + upgrades + handlers (if applicable)
       else if (unit.counterpart) {
-        const cAddUpgradeHandlers = [];
-        const cSwapUpgradeHandlers = [];
-        const cZoomUpgradeHandlers = [];
-        const cDeleteUpgradeHandlers = [];
-        const cChangeLoadoutHandlers = [];
-        const cDeleteLoadoutHandlers = [];
-        const counterpart = unit.counterpart;
-        const cLoadoutUpgrades = counterpart.loadoutUpgrades;
-        // TODO - a lot of this can and should be pushed down to endpoint components via context
-        counterpart.upgradesEquipped.forEach((upgradeId, upgradeIndex) => {
-          const upgradeType = counterpartCard.upgradeBar[upgradeIndex];
-          if (upgradeId) {
-            cZoomUpgradeHandlers.push(() => handleCardZoom(upgradeId));
-            cSwapUpgradeHandlers.push(() => setCardPaneFilter({
-              action: 'COUNTERPART_UPGRADE',
-              upgradeType, unitIndex, upgradeIndex, counterpartId,
-              upgradesEquipped: counterpart.upgradesEquipped,
-              additionalUpgradeSlots: []
-            }));
-            cAddUpgradeHandlers.push(undefined);
-            cDeleteUpgradeHandlers.push(() => handleUnequipUpgrade(
-              'COUNTERPART_UPGRADE', unitIndex, upgradeIndex
-            ));
-            if (hasLoadout && Boolean(cLoadoutUpgrades[upgradeIndex])) {
-              cChangeLoadoutHandlers.push(() => setCardPaneFilter({
-                action: 'COUNTERPART_LOADOUT_UPGRADE',
-                upgradeType, unitIndex, upgradeIndex, counterpartId,
-                upgradesEquipped: counterpart.upgradesEquipped,
-                additionalUpgradeSlots: []
-              }));
-              cDeleteLoadoutHandlers.push(() => handleUnequipUpgrade(
-                'COUNTERPART_LOADOUT_UPGRADE', unitIndex, upgradeIndex
-              ));
-            } else if (hasLoadout && !cLoadoutUpgrades[upgradeIndex]) {
-              cChangeLoadoutHandlers.push(() => setCardPaneFilter({
-                action: 'COUNTERPART_LOADOUT_UPGRADE',
-                upgradeType, unitIndex, upgradeIndex, counterpartId,
-                upgradesEquipped: counterpart.upgradesEquipped,
-                additionalUpgradeSlots: []
-              }));
-              cDeleteLoadoutHandlers.push(undefined)
-            }
-          } else {
-            cZoomUpgradeHandlers.push(undefined);
-            cSwapUpgradeHandlers.push(undefined);
-            cAddUpgradeHandlers.push(() => setCardPaneFilter({
-              action: 'COUNTERPART_UPGRADE',
-              upgradeType, unitIndex, upgradeIndex, counterpartId,
-              upgradesEquipped: counterpart.upgradesEquipped,
-              additionalUpgradeSlots: []
-            }));
-            cDeleteUpgradeHandlers.push(undefined);
-            if (hasLoadout) {
-              cChangeLoadoutHandlers.push(undefined);
-              cDeleteLoadoutHandlers.push(undefined);
-            }
-          }
-        });
         counterpartUnit = (
-          <CounterpartUnit
-            counterpart={unit.counterpart}
-            counterpartId={counterpartId}
-            counterpartCard={counterpartCard}
-            unitIndex={unitIndex}
-            handleCardZoom={() => handleCardZoom(counterpartId)}
-            zoomUpgradeHandlers={cZoomUpgradeHandlers}
-            swapUpgradeHandlers={cSwapUpgradeHandlers}
-            addUpgradeHandlers={cAddUpgradeHandlers}
-            deleteUpgradeHandlers={cDeleteUpgradeHandlers}
-            changeLoadoutHandlers={cChangeLoadoutHandlers}
-            deleteLoadoutHandlers={cDeleteLoadoutHandlers}
-          />
+          <UnitContext.Provider 
+            value={{
+              unit: unit.counterpart,
+              unitIndex,
+              unitCard: counterpartCard,
+              totalUpgradeBar:[...counterpartCard.upgradeBar, ...unit.counterpart.additionalUpgradeSlots],
+              actionPrefix:"COUNTERPART"
+            }}
+          >
+            <CounterpartUnit/>
+          </UnitContext.Provider>
         );
       }
     }
 
-    unit.upgradesEquipped.forEach((upgradeId, upgradeIndex) => {
-      const upgradeType = totalUpgradeBar[upgradeIndex];
-      if (upgradeId) {
-        zoomUpgradeHandlers.push(() => handleCardZoom(upgradeId));
-        addUpgradeHandlers.push(undefined);
-        swapUpgradeHandlers.push(() => setCardPaneFilter({
-          action: 'UNIT_UPGRADE',
-          upgradeType, unitIndex, upgradeIndex,
-          hasUniques: unit.hasUniques,
-          unitId: unitCard.id,
-          upgradesEquipped: unit.upgradesEquipped,
-          additionalUpgradeSlots: unit.additionalUpgradeSlots
-        }));
-        deleteUpgradeHandlers.push(() => handleUnequipUpgrade(
-          'UNIT_UPGRADE', unitIndex, upgradeIndex
-        ));
-        if (hasLoadout && loadoutUpgrades[upgradeIndex]) {
-          changeLoadoutHandlers.push(() => setCardPaneFilter({
-            action: 'LOADOUT_UPGRADE',
-            upgradeType, unitIndex, upgradeIndex,
-            unitId: unitCard.id,
-            upgradesEquipped: unit.upgradesEquipped,
-            additionalUpgradeSlots: unit.additionalUpgradeSlots
-          }));
-          deleteLoadoutHandlers.push(() => handleUnequipUpgrade(
-            'LOADOUT_UPGRADE', unitIndex, upgradeIndex
-          ));
-        } else if (hasLoadout && !loadoutUpgrades[upgradeIndex]) {
-          changeLoadoutHandlers.push(() => setCardPaneFilter({
-            action: 'LOADOUT_UPGRADE',
-            upgradeType, unitIndex, upgradeIndex,
-            unitId: unitCard.id,
-            upgradesEquipped: unit.upgradesEquipped,
-            additionalUpgradeSlots: unit.additionalUpgradeSlots
-          }));
-          deleteLoadoutHandlers.push(undefined)
-        }
-      } else {
-        zoomUpgradeHandlers.push(undefined);
-        swapUpgradeHandlers.push(undefined);
-        addUpgradeHandlers.push(() => setCardPaneFilter({
-          action: 'UNIT_UPGRADE',
-          upgradeType, unitIndex, upgradeIndex,
-          hasUniques: unit.hasUniques,
-          unitId: unitCard.id,
-          upgradesEquipped: unit.upgradesEquipped,
-          additionalUpgradeSlots: unit.additionalUpgradeSlots
-        }));
-        deleteUpgradeHandlers.push(undefined);
-        if (hasLoadout) {
-          changeLoadoutHandlers.push(undefined);
-          deleteLoadoutHandlers.push(undefined);
-        }
-      }
-    });
     return {
       id: unit.unitObjectString,
       component: (
-        <ListUnit
-          unit={unit}
-          uniques={currentList.uniques}
-          unitCard={unitCard}
-          unitIndex={unitIndex}
-          counterpartId={counterpartId}
-          counterpartUnit={counterpartUnit}
-          handleCardZoom={() => handleCardZoom(unit.unitId)}
-          addCounterpartHandler={addCounterpartHandler}
-          zoomUpgradeHandlers={zoomUpgradeHandlers}
-          swapUpgradeHandlers={swapUpgradeHandlers}
-          addUpgradeHandlers={addUpgradeHandlers}
-          deleteUpgradeHandlers={deleteUpgradeHandlers}
-          changeLoadoutHandlers={changeLoadoutHandlers}
-          deleteLoadoutHandlers={deleteLoadoutHandlers}
-        />
+        <UnitContext.Provider 
+          value={{
+            unit,
+            unitIndex,
+            unitCard,
+            totalUpgradeBar:[...unitCard.upgradeBar, ...unit.additionalUpgradeSlots],
+            actionPrefix:"UNIT"
+          }}
+        >
+          <ListUnit
+            counterpartUnit={counterpartUnit}
+            addCounterpartHandler={addCounterpartHandler}
+          />
+        </UnitContext.Provider>
       )
     }
   });

--- a/src/pages/List/ListUnits/index.js
+++ b/src/pages/List/ListUnits/index.js
@@ -39,6 +39,7 @@ function ListUnits() {
               unitIndex,
               unitCard: counterpartCard,
               totalUpgradeBar:[...counterpartCard.upgradeBar, ...unit.counterpart.additionalUpgradeSlots],
+              // TODO: this is not *great*; relies on card funcs following "COUNTERPART_UPGRADE" et al to work
               actionPrefix:"COUNTERPART"
             }}
           >
@@ -57,6 +58,7 @@ function ListUnits() {
             unitIndex,
             unitCard,
             totalUpgradeBar:[...unitCard.upgradeBar, ...unit.additionalUpgradeSlots],
+            // TODO: this is not *great*; relies on card funcs following "UNIT_UPGRADE" et al to work
             actionPrefix:"UNIT"
           }}
         >

--- a/src/pages/List/ListUnits/index.js
+++ b/src/pages/List/ListUnits/index.js
@@ -16,7 +16,6 @@ function ListUnits() {
   const items = currentList.units.map((unit, unitIndex) => {
     const unitCard = cards[unit.unitId];
     const { counterpartId } = unitCard;
-    const counterpartCard = cards[counterpartId];
     let counterpartUnit = null;
     let addCounterpartHandler;
     
@@ -30,8 +29,10 @@ function ListUnits() {
           });
         }
       }
-      // else, if unit has counterpart equipped, render it + upgrades + handlers (if applicable)
+      // else, if unit has counterpart equipped, render it
       else if (unit.counterpart) {
+        const counterpartCard = cards[counterpartId];
+
         counterpartUnit = (
           <UnitContext.Provider 
             value={{
@@ -41,8 +42,7 @@ function ListUnits() {
               totalUpgradeBar:[...counterpartCard.upgradeBar, ...unit.counterpart.additionalUpgradeSlots],
               // TODO: this is not *great*; relies on card funcs following "COUNTERPART_UPGRADE" et al to work
               actionPrefix:"COUNTERPART"
-            }}
-          >
+          }}>
             <CounterpartUnit/>
           </UnitContext.Provider>
         );
@@ -60,8 +60,7 @@ function ListUnits() {
             totalUpgradeBar:[...unitCard.upgradeBar, ...unit.additionalUpgradeSlots],
             // TODO: this is not *great*; relies on card funcs following "UNIT_UPGRADE" et al to work
             actionPrefix:"UNIT"
-          }}
-        >
+        }}>
           <ListUnit
             counterpartUnit={counterpartUnit}
             addCounterpartHandler={addCounterpartHandler}


### PR DESCRIPTION
Use a context provider instead of creating/passing all unit handlers (add upgrade, change upgrade, zoom, etc) from ListUnits/index.js via props.

Kind of a big paradigm shift, but man, it cleans up the prop handoffs so, so nicely.

This should be less radical in terms of changed functionality than it may look on first glance, but still might want some more testing before going live. So far, I haven't seen anything break via playing with a few lists, particularly Iden's damnable Counterpart+Loadout interactions.